### PR TITLE
fix(ci): reduce staging channel expires from 90d to 30d (Firebase limit)

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -508,7 +508,7 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
           projectId: '${{ secrets.FIREBASE_PROJECT_ID }}'
           channelId: staging
-          expires: 90d
+          expires: 30d
 
   # Deploy to production (requires manual approval) (A11)
   deploy-production:


### PR DESCRIPTION
## Problem
Staging deployment in PR #14 is failing with:
```
Error: "expires" flag may not be longer than 30d
```

## Root Cause
Firebase Hosting changed the maximum channel expiry from 90 days to 30 days. The staging deployment was still configured with `expires: 90d`.

## Solution
Updated `.github/workflows/flutter.yml`:
- Changed staging channel `expires: 90d` → `expires: 30d`
- Aligns with Firebase Hosting's current 30-day maximum limit

## Impact
- ✅ Fixes staging deployment failure
- ✅ Unblocks PR #14 (staging → main release)
- ✅ No functional changes to deployment behavior
- ✅ Staging channel still has sufficient expiry (30 days is appropriate for a staging environment)

## Testing
- CI will validate the workflow syntax
- Staging deployment will succeed once merged
- Preview deployments already use 7d (unaffected)

## References
- Firebase Hosting documentation on channel expiry limits
- Error log: https://github.com/PD2015/wildfire_mvp_v3/actions/runs/19012147857