### PR TITLE
fix: increase GPS timeout for rural areas

### DIFF
--- a/lib/controllers/home_controller.dart
+++ b/lib/controllers/home_controller.dart
@@ -30,7 +30,11 @@ import '../config/feature_flags.dart';
 /// - C2: Privacy-first logging (no raw coordinates)
 /// - C5: Resilient error handling with visible retry options
 class HomeController extends ChangeNotifier {
-  static const Duration _globalDeadline = Duration(seconds: 8);
+  /// Global deadline for entire load operation (location + fire risk data)
+  /// Web needs longer timeout (15s) for GPS acquisition in rural/slow areas
+  /// Native platforms are faster (10s) with direct hardware access
+  static Duration get _globalDeadline =>
+      kIsWeb ? const Duration(seconds: 15) : const Duration(seconds: 10);
 
   final LocationResolver _locationResolver;
   final FireRiskService _fireRiskService;


### PR DESCRIPTION
## Summary
Increases the global deadline for web GPS acquisition to support rural areas with slower GPS lock times.

## Problem
- GPS resolver has 10s timeout for web
- HomeController global deadline was 8s
- GPS would succeed after ~10s but controller already timed out at 8s
- User sees fallback to Aviemore, then GPS loads a few seconds later

## Solution
Made `_globalDeadline` platform-aware:
| Platform | GPS Timeout | Global Deadline |
|----------|-------------|-----------------|
| **Web** | 10s | 15s (was 8s) |
| **Native** | 3s | 10s (was 8s) |

The extra headroom accounts for:
- Slow GPS acquisition in rural areas
- First-time GPS permission grants
- Fire risk API call after GPS resolves

## Testing
- Tested in incognito mode where GPS permission must be re-granted
- GPS now has time to complete before global timeout

## Related
- Follows up on PR #58 (GPS fixes)