### PR TITLE
fix(ci): reduce staging deploy expires from 90d to 30d

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -508,7 +508,7 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
           projectId: '${{ secrets.FIREBASE_PROJECT_ID }}'
           channelId: staging
-          expires: 90d
+          expires: 30d
 
   # Deploy to production (requires manual approval) (A11)
   deploy-production:


### PR DESCRIPTION
## Summary
Firebase Hosting preview channels have a maximum expiry of 30 days.

## Problem
The staging deployment was failing with error:
```
"expires" flag may not be longer than 30d
```

## Fix
Changed `expires: 90d` to `expires: 30d` in the staging deployment workflow.

## Related
Fixes failed run from PR #76 merge to staging.